### PR TITLE
Pass the HMAC algorithm to the server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../Cyclid-core/
   specs:
-    cyclid-core (0.1.0)
+    cyclid-core (0.1.1)
       rack (~> 1.6)
 
 PATH

--- a/lib/cyclid/client/api/hmac.rb
+++ b/lib/cyclid/client/api/hmac.rb
@@ -23,7 +23,8 @@ module Cyclid
       class Hmac < Base
         # Sign the request with HMAC
         def authenticate_request(request, uri)
-          signer = Cyclid::HMAC::Signer.new
+          algorithm = 'sha256'
+          signer = Cyclid::HMAC::Signer.new(algorithm)
 
           method = if request.is_a? Net::HTTP::Get
                      'GET'
@@ -48,6 +49,7 @@ module Cyclid
           headers[0].each do |k, v|
             request[k] = v
           end
+          request['X-HMAC-Algorithm'] = algorithm
 
           return request
         end

--- a/spec/client/api/hmac_spec.rb
+++ b/spec/client/api/hmac_spec.rb
@@ -24,6 +24,7 @@ describe Cyclid::Client::Api::Hmac do
       api_request = nil
       expect{ api_request = subject.authenticate_request(request, uri) }.to_not raise_error
       expect(api_request.key?('x-hmac-nonce')).to be(true)
+      expect(api_request.key?('x-hmac-algorithm')).to be(true)
       expect(api_request.key?('authorization')).to be(true)
       expect(api_request.key?('date')).to be(true)
     end
@@ -34,6 +35,7 @@ describe Cyclid::Client::Api::Hmac do
       api_request = nil
       expect{ api_request = subject.authenticate_request(request, uri) }.to_not raise_error
       expect(api_request.key?('x-hmac-nonce')).to be(true)
+      expect(api_request.key?('x-hmac-algorithm')).to be(true)
       expect(api_request.key?('authorization')).to be(true)
       expect(api_request.key?('date')).to be(true)
     end
@@ -44,6 +46,7 @@ describe Cyclid::Client::Api::Hmac do
       api_request = nil
       expect{ api_request = subject.authenticate_request(request, uri) }.to_not raise_error
       expect(api_request.key?('x-hmac-nonce')).to be(true)
+      expect(api_request.key?('x-hmac-algorithm')).to be(true)
       expect(api_request.key?('authorization')).to be(true)
       expect(api_request.key?('date')).to be(true)
     end
@@ -54,6 +57,7 @@ describe Cyclid::Client::Api::Hmac do
       api_request = nil
       expect{ api_request = subject.authenticate_request(request, uri) }.to_not raise_error
       expect(api_request.key?('x-hmac-nonce')).to be(true)
+      expect(api_request.key?('x-hmac-algorithm')).to be(true)
       expect(api_request.key?('authorization')).to be(true)
       expect(api_request.key?('date')).to be(true)
     end
@@ -93,7 +97,8 @@ describe Cyclid::Client::Api::Hmac do
                          'Host' => 'example.com:9999',
                          'User-Agent' => 'Ruby',
                          'Date' => /.*/,
-                         'X-Hmac-Nonce' => /.*/ })
+                         'X-Hmac-Nonce' => /.*/,
+                         'X-Hmac-Algorithm' => /.*/ })
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       res = nil
@@ -111,7 +116,8 @@ describe Cyclid::Client::Api::Hmac do
                          'Host' => 'example.com:9999',
                          'User-Agent' => 'Ruby',
                          'Date' => /.*/,
-                         'X-Hmac-Nonce' => /.*/ })
+                         'X-Hmac-Nonce' => /.*/,
+                         'X-Hmac-Algorithm' => /.*/ })
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       expect{ subject.api_json_post(uri, 'test' => 'json') }.to_not raise_error
@@ -127,7 +133,8 @@ describe Cyclid::Client::Api::Hmac do
                          'Host' => 'example.com:9999',
                          'User-Agent' => 'Ruby',
                          'Date' => /.*/,
-                         'X-Hmac-Nonce' => /.*/ })
+                         'X-Hmac-Nonce' => /.*/,
+                         'X-Hmac-Algorithm' => /.*/ })
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       expect{ subject.api_yaml_post(uri, 'test' => 'yaml') }.to_not raise_error
@@ -143,7 +150,8 @@ describe Cyclid::Client::Api::Hmac do
                          'Host' => 'example.com:9999',
                          'User-Agent' => 'Ruby',
                          'Date' => /.*/,
-                         'X-Hmac-Nonce' => /.*/ })
+                         'X-Hmac-Nonce' => /.*/,
+                         'X-Hmac-Algorithm' => /.*/ })
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       expect{ subject.api_json_put(uri, 'test' => 'json') }.to_not raise_error
@@ -157,7 +165,8 @@ describe Cyclid::Client::Api::Hmac do
                          'Host' => 'example.com:9999',
                          'User-Agent' => 'Ruby',
                          'Date' => /.*/,
-                         'X-Hmac-Nonce' => /.*/ })
+                         'X-Hmac-Nonce' => /.*/,
+                         'X-Hmac-Algorithm' => /.*/ })
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       expect{ subject.api_delete(uri) }.to_not raise_error


### PR DESCRIPTION
Add the X-HMAC-Algorithm header to every HMAC signed request so that the
server can select the correct algorithm on it's side; this will allow us
to change the default algorithm in future but maintain forward compatability.