### PR TITLE
Vanders/healthcheck

### DIFF
--- a/lib/cyclid/client.rb
+++ b/lib/cyclid/client.rb
@@ -26,6 +26,7 @@ require 'cyclid/client/organization'
 require 'cyclid/client/job'
 require 'cyclid/client/stage'
 require 'cyclid/client/auth'
+require 'cyclid/client/health'
 
 module Cyclid
   # Cyclid client methods
@@ -76,6 +77,7 @@ module Cyclid
       include Job
       include Stage
       include Auth
+      include Health
 
       private
 

--- a/lib/cyclid/client.rb
+++ b/lib/cyclid/client.rb
@@ -60,6 +60,8 @@ module Cyclid
 
         # Select the API methods to use
         @api = case @config.auth
+               when AuthMethods::AUTH_NONE
+                 Api::None.new(@config, @logger)
                when AuthMethods::AUTH_HMAC
                  Api::Hmac.new(@config, @logger)
                when AuthMethods::AUTH_BASIC

--- a/lib/cyclid/client/api.rb
+++ b/lib/cyclid/client/api.rb
@@ -108,6 +108,7 @@ module Cyclid
   end
 end
 
+require 'cyclid/client/api/none'
 require 'cyclid/client/api/hmac'
 require 'cyclid/client/api/basic'
 require 'cyclid/client/api/token'

--- a/lib/cyclid/client/api/none.rb
+++ b/lib/cyclid/client/api/none.rb
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 module Cyclid
+  # Cyclid client methods
   module Client
-    # Possible authentication methods
-    module AuthMethods
-      AUTH_NONE = 0,
-      AUTH_HMAC = 1,
-      AUTH_BASIC = 2,
-      AUTH_TOKEN = 3
+    # Client API HTTP methods
+    module Api
+      # Only works for non-authenticated request (E.g. healthchecks)
+      class None < Base
+        # Do nothing
+        def authenticate_request(request, _uri)
+          request
+        end
+      end
     end
   end
 end

--- a/lib/cyclid/client/health.rb
+++ b/lib/cyclid/client/health.rb
@@ -1,0 +1,34 @@
+# Copyright 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Cyclid
+  module Client
+    # Health-check related methods
+    module Health
+      # Ping the API server.
+      # @return [Hash] Decoded server response object.
+      def health_ping
+        uri = server_uri('/health/status')
+
+        # We need to do without the API helpers as the health endpoint won't
+        # return any data, just an HTTP status
+        req = authenticate_request(Net::HTTP::Get.new(uri), uri)
+        http = Net::HTTP.new(uri.hostname, uri.port)
+        res = http.request(req)
+
+        return res.code == '200'
+      end
+    end
+  end
+end

--- a/lib/cyclid/client/health.rb
+++ b/lib/cyclid/client/health.rb
@@ -17,7 +17,7 @@ module Cyclid
     # Health-check related methods
     module Health
       # Ping the API server.
-      # @return [Hash] Decoded server response object.
+      # @return [Boolean] True if the API server is healthy, false if it is unhealthy.
       def health_ping
         uri = server_uri('/health/status')
 

--- a/lib/cyclid/config.rb
+++ b/lib/cyclid/config.rb
@@ -59,6 +59,8 @@ module Cyclid
         # Select the authentication type & associated authentication data.
         @auth = options[:auth] || AUTH_HMAC
         case @auth
+        when AUTH_NONE
+          # Nothing
         when AUTH_HMAC
           @secret = options[:secret] || @config['secret']
         when AUTH_BASIC
@@ -83,7 +85,7 @@ module Cyclid
 
         # Server & Username *must* be set
         raise 'server address must be provided' if @server.nil?
-        raise 'username must be provided' if @username.nil?
+        raise 'username must be provided' if @username.nil? and @auth != AUTH_NONE
       end
     end
   end

--- a/spec/client/api/none_spec.rb
+++ b/spec/client/api/none_spec.rb
@@ -1,0 +1,27 @@
+require 'client_helper'
+
+describe Cyclid::Client::Api::Basic do
+  context 'passing through requests' do
+    let :config do
+      dbl = instance_double(Cyclid::Client::Config)
+      allow(dbl).to receive(:auth).and_return(Cyclid::Client::AuthMethods::AUTH_NONE)
+      return dbl
+    end
+
+    let :uri do
+      URI('http://example.com/example/test')
+    end
+
+    subject do
+      Cyclid::Client::Api::None.new(config, Logger.new(STDERR))
+    end
+
+    it 'does nothing to a request' do
+      request = Net::HTTP::Get.new(uri)
+
+      api_request = nil
+      expect{ api_request = subject.authenticate_request(request, uri) }.to_not raise_error
+      expect(api_request.key?('authorization')).to be(false)
+    end
+  end
+end

--- a/spec/client/health_spec.rb
+++ b/spec/client/health_spec.rb
@@ -3,9 +3,9 @@ require 'client_helper'
 describe Cyclid::Client::Health do
   context 'retrieving the API health' do
     let :config do
-      {auth: Cyclid::Client::AUTH_NONE,
-       server: 'example.com',
-       port: 9999}
+      { auth: Cyclid::Client::AUTH_NONE,
+        server: 'example.com',
+        port: 9999 }
     end
 
     subject do
@@ -17,7 +17,7 @@ describe Cyclid::Client::Health do
         .with(headers: { 'Accept' => '*/*',
                          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
                          'Host' => 'example.com:9999',
-                         'User-Agent' => 'Ruby'})
+                         'User-Agent' => 'Ruby' })
         .to_return(status: 200)
 
       status = nil
@@ -30,7 +30,7 @@ describe Cyclid::Client::Health do
         .with(headers: { 'Accept' => '*/*',
                          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
                          'Host' => 'example.com:9999',
-                         'User-Agent' => 'Ruby'})
+                         'User-Agent' => 'Ruby' })
         .to_return(status: 503)
 
       status = nil

--- a/spec/client/health_spec.rb
+++ b/spec/client/health_spec.rb
@@ -1,0 +1,41 @@
+require 'client_helper'
+
+describe Cyclid::Client::Health do
+  context 'retrieving the API health' do
+    let :config do
+      {auth: Cyclid::Client::AUTH_NONE,
+       server: 'example.com',
+       port: 9999}
+    end
+
+    subject do
+      Cyclid::Client::Tilapia.new(config)
+    end
+
+    it 'retrieves the health status when the server is healthy' do
+      stub_request(:get, 'http://example.com:9999/health/status')
+        .with(headers: { 'Accept' => '*/*',
+                         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Host' => 'example.com:9999',
+                         'User-Agent' => 'Ruby'})
+        .to_return(status: 200)
+
+      status = nil
+      expect{ status = subject.health_ping }.to_not raise_error
+      expect(status).to be true
+    end
+
+    it 'retrieves the health status when the server is not healthy' do
+      stub_request(:get, 'http://example.com:9999/health/status')
+        .with(headers: { 'Accept' => '*/*',
+                         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Host' => 'example.com:9999',
+                         'User-Agent' => 'Ruby'})
+        .to_return(status: 503)
+
+      status = nil
+      expect{ status = subject.health_ping }.to_not raise_error
+      expect(status).to be false
+    end
+  end
+end


### PR DESCRIPTION
Add AUTH_NONE and provide a pass-through API authenticator that does nothing
to the request.
Allow the username to not be set when AUTH_NONE is used.
Add the health_ping method to "ping" the API /health/status endpoint and return the
status.